### PR TITLE
add mobile web app support for Chrome on Android

### DIFF
--- a/src/index.html
+++ b/src/index.html
@@ -69,6 +69,7 @@
 	<!-- /build -->
     
 	<meta content="width=device-width, initial-scale=1, maximum-scale=1, user-scaleable=no" name="viewport" />
+	<meta name="mobile-web-app-capable" content="yes">
 	
 	<link rel="shortcut icon" type="image/ico" href="assets/favicon.ico" />
 	<link rel="shortcut icon" type="image/x-icon" href="assets/favicon.ico" />


### PR DESCRIPTION
I added support for a real webapp feeling on Android phones according to the [Chrome Developer Guide](https://developer.chrome.com/multidevice/android/installtohomescreen).

I might later add the more recent `manifest.json` version of this, but this was the quicker fix and it works just like a charm. :wink: 